### PR TITLE
Add `freertos` feature to allow sharing of `ShiftRegisterPin` between tasks/threads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shift-register-driver"
 version = "0.1.1"
-edition = "2018"
+edition = "2021"
 authors = ["Josh Mcguigan"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Platform agnostic driver for shift register's built using the embedded-hal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 embedded-hal = "0.2.1"
-freertos-rust = {version = "*", optional = true}
+freertos-rust = { version = "*", optional = true }
 
 [features]
 freertos = ["freertos-rust"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "shift-register-driver"
 version = "0.1.1"
+edition = "2018"
 authors = ["Josh Mcguigan"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Platform agnostic driver for shift register's built using the embedded-hal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ readme = "README.md"
 
 [dependencies]
 embedded-hal = "0.2.1"
+freertos-rust = {version = "*", optional = true}
+
+[features]
+freertos = ["freertos-rust"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 ```rust
     use shift_register_driver::sipo::ShiftRegister;
+    use embedded_hal::digital::v2::OutputPin;
+
     let shift_register = ShiftRegister::new(clock, latch, data);
     {
         let mut outputs = shift_register.decompose();

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - Controlling outputs through serial-in parallel-out shift registers with 8 outputs
 - Chaining shift registers up to 128 outputs
+- use the `freertos` feature to use with [freertos-rust](https://github.com/lobaro/FreeRTOS-rust)
 
 ## TODO
 
@@ -16,7 +17,9 @@
 ```rust
     use shift_register_driver::sipo::ShiftRegister;
     use embedded_hal::digital::v2::OutputPin;
+```
 
+```rust
     let shift_register = ShiftRegister::new(clock, latch, data);
     {
         let mut outputs = shift_register.decompose();

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -37,7 +37,7 @@ impl<'a> ShiftRegisterPin<'a>
     }
 }
 
-impl OutputPin for ShiftRegisterPin<'_>
+impl<'a> OutputPin for ShiftRegisterPin<'a>
 {
     type Error = ();
 

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -1,7 +1,7 @@
 //! Serial-in parallel-out shift register
 
 use core::cell::RefCell;
-use hal::digital::OutputPin;
+use hal::digital::v2::OutputPin;
 use core::mem;
 use core::ptr;
 

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -15,12 +15,15 @@ trait ShiftRegisterInternal {
     fn update(&self, index: usize, command: bool) -> Result<(), ()>;
 }
 
+
 #[cfg(feature = "freertos")]
 trait ShiftRegisterInternal: Sync {
     fn update(&self, index: usize, command: bool) -> Result<(), ()>;
 }
 
 /// Output pin of the shift register
+#[cfg(feature = "freertos")]
+#[derive(Clone, Copy)]
 pub struct ShiftRegisterPin<'a>
 {
     shift_register: &'a dyn ShiftRegisterInternal,
@@ -235,7 +238,7 @@ macro_rules! ShiftRegisterBuilder {
             }
 
             /// Get embedded-hal output pins to control the shift register outputs
-            pub fn decompose(& self) ->  [ShiftRegisterPin; $size] {
+            pub fn decompose(&self) ->  [ShiftRegisterPin; $size] {
 
                 // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
                 // safe because the type we are claiming to have initialized here is a

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -3,9 +3,9 @@
 use core::cell::RefCell;
 use core::mem;
 
-use hal::digital::v2::OutputPin;
+use crate::hal::digital::v2::OutputPin;
 
-use sipo::mem::MaybeUninit;
+use crate::sipo::mem::MaybeUninit;
 
 trait ShiftRegisterInternal {
     fn update(&self, index: usize, command: bool) -> Result<(), ()>;

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -16,8 +16,6 @@ pub struct ShiftRegisterPin<'a>
     index: usize,
 }
 
-unsafe impl<'a> Sync for ShiftRegisterPin<'a> {}
-
 impl<'a> ShiftRegisterPin<'a>
 {
     fn new(shift_register: &'a dyn ShiftRegisterInternal, index: usize) -> Self {

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -91,7 +91,7 @@ macro_rules! ShiftRegisterBuilder {
                 let mut pins: [ShiftRegisterPin; $size];
 
                 unsafe {
-                    pins = mem::uninitialized();
+                    pins = mem::MaybeUninit::uninit();
                     for (index, elem) in pins[..].iter_mut().enumerate() {
                         ptr::write(elem, ShiftRegisterPin::new(self, index));
                     }

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -235,7 +235,7 @@ macro_rules! ShiftRegisterBuilder {
             }
 
             /// Get embedded-hal output pins to control the shift register outputs
-            pub fn decompose(&self) ->  [ShiftRegisterPin; $size] {
+            pub fn decompose(&'static self) ->  [ShiftRegisterPin; $size] {
 
                 // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
                 // safe because the type we are claiming to have initialized here is a

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -235,7 +235,7 @@ macro_rules! ShiftRegisterBuilder {
             }
 
             /// Get embedded-hal output pins to control the shift register outputs
-            pub fn decompose(&'static self) ->  [ShiftRegisterPin; $size] {
+            pub fn decompose<'a>(&'a self) ->  [ShiftRegisterPin; $size] {
 
                 // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
                 // safe because the type we are claiming to have initialized here is a

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -12,25 +12,29 @@ trait ShiftRegisterInternal {
 /// Output pin of the shift register
 pub struct ShiftRegisterPin<'a>
 {
-    shift_register: &'a ShiftRegisterInternal,
+    shift_register: &'a dyn ShiftRegisterInternal,
     index: usize,
 }
 
 impl<'a> ShiftRegisterPin<'a>
 {
-    fn new(shift_register: &'a ShiftRegisterInternal, index: usize) -> Self {
+    fn new(shift_register: &'a dyn ShiftRegisterInternal, index: usize) -> Self {
         ShiftRegisterPin { shift_register, index }
     }
 }
 
 impl<'a> OutputPin for ShiftRegisterPin<'a>
 {
-    fn set_low(&mut self) {
+    type Error = ();
+
+    fn set_low(&mut self) -> Result<(), ()> {
         self.shift_register.update(self.index, false);
+        Ok(())
     }
 
-    fn set_high(&mut self) {
+    fn set_high(&mut self) -> Result<(), ()> {
         self.shift_register.update(self.index, true);
+        Ok(())
     }
 }
 

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -4,6 +4,7 @@ use core::cell::RefCell;
 use core::mem;
 
 use hal::digital::v2::OutputPin;
+
 use sipo::mem::MaybeUninit;
 
 trait ShiftRegisterInternal {

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -1,11 +1,9 @@
 //! Serial-in parallel-out shift register
 
 use core::cell::RefCell;
-use core::mem;
+use core::mem::{self, MaybeUninit};
 
 use crate::hal::digital::v2::OutputPin;
-
-use crate::sipo::mem::MaybeUninit;
 
 trait ShiftRegisterInternal {
     fn update(&self, index: usize, command: bool) -> Result<(), ()>;
@@ -102,7 +100,7 @@ macro_rules! ShiftRegisterBuilder {
                 // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
                 // safe because the type we are claiming to have initialized here is a
                 // bunch of `MaybeUninit`s, which do not require initialization.
-                let mut pins:  [mem::MaybeUninit<ShiftRegisterPin>; $size] = unsafe {
+                let mut pins:  [MaybeUninit<ShiftRegisterPin>; $size] = unsafe {
                     MaybeUninit::uninit().assume_init()
                 };
 

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -158,7 +158,7 @@ macro_rules! ShiftRegisterBuilder {
             clock: Arc<Mutex<Pin1>>,
             latch: Arc<Mutex<Pin2>>,
             data: Arc<Mutex<Pin3>>,
-            output_state:  Arc<Mutex<[bool; $size]>>,
+            output_state: Arc<Mutex<[bool; $size]>>,
         }
 
         impl<Pin1, Pin2, Pin3> ShiftRegisterInternal for $name<Pin1, Pin2, Pin3>
@@ -235,7 +235,7 @@ macro_rules! ShiftRegisterBuilder {
             }
 
             /// Get embedded-hal output pins to control the shift register outputs
-            pub fn decompose<'a>(&'a self) ->  [ShiftRegisterPin; $size] {
+            pub fn decompose(& self) ->  [ShiftRegisterPin; $size] {
 
                 // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
                 // safe because the type we are claiming to have initialized here is a

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -18,6 +18,8 @@ pub struct ShiftRegisterPin<'a>
     index: usize,
 }
 
+unsafe impl<'a> Sync for ShiftRegisterPin<'a> {}
+
 impl<'a> ShiftRegisterPin<'a>
 {
     fn new(shift_register: &'a dyn ShiftRegisterInternal, index: usize) -> Self {


### PR DESCRIPTION
This addresses #4, it compiles but I will only be able to test it on hardware in a couple of weeks. I had to remove the `release()` function - maybe someone can implement it again.

This PR is already based on #2 which updates this library to `embedded_hal::digital::v2`.