### PR TITLE
Provide a way to update all the values in one go

### DIFF
--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -92,6 +92,19 @@ where
         core::array::from_fn(|i| ShiftRegisterPin::<'_, Pin1, Pin2, Pin3, N>::new(self, i))
     }
 
+    /// Modify all the values in one go
+    ///
+    /// Modify the passed-in slice to the values you want the shift register(s)
+    /// to have. `true` means high and `false` means low.
+    pub fn modify<F>(&self, fun: F) -> Result<(), SRErr<Pin1, Pin2, Pin3>>
+        where F: FnOnce(&mut [bool; N])
+    {
+        let mut output_state = self.output_state.borrow_mut();
+        fun(&mut output_state);
+        drop(output_state);
+        self.send_value()
+    }
+
     /// Consume the shift register and return the original clock, latch, and data output pins
     pub fn release(self) -> (Pin1, Pin2, Pin3) {
         let Self {

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -88,6 +88,9 @@ where
     }
 
     /// Get embedded-hal output pins to control the shift register outputs
+    ///
+    /// Use this if you intend to use the shift register as an output
+    /// multiplexer and want to treat the outputs as regular pins.
     pub fn decompose(&self) -> [ShiftRegisterPin<'_, Pin1, Pin2, Pin3, N>; N] {
         core::array::from_fn(|i| ShiftRegisterPin::<'_, Pin1, Pin2, Pin3, N>::new(self, i))
     }

--- a/src/sipo.rs
+++ b/src/sipo.rs
@@ -103,16 +103,10 @@ where
         (clock.into_inner(), latch.into_inner(), data.into_inner())
     }
 
-    fn update(
-        &self,
-        index: usize,
-        command: bool,
-    ) -> Result<
-        (),
-        SRErr<Pin1, Pin2, Pin3>,
-    > {
-        self.output_state.borrow_mut()[index] = command;
+    /// Send out the data to the shift registers
+    fn send_value(&self) -> Result<(), SRErr<Pin1, Pin2, Pin3>> {
         let output_state = self.output_state.borrow();
+
         self.latch
             .borrow_mut()
             .set_low()
@@ -145,6 +139,18 @@ where
             .set_high()
             .map_err(SRError::LatchPinError)?;
         Ok(())
+    }
+
+    fn update(
+        &self,
+        index: usize,
+        command: bool,
+    ) -> Result<
+        (),
+        SRErr<Pin1, Pin2, Pin3>,
+    > {
+        self.output_state.borrow_mut()[index] = command;
+        self.send_value()
     }
 }
 


### PR DESCRIPTION
As discussed in #1 it is sometimes useful to update all the bits at once instead of treating them like pins. When you're treating it as a multiplexer, `decompose()` makes sense but in the case where you're using the shift register to reduce the amount of pins you need in order to create large values, e.g. if you're setting an address for an EEPROM that wants 16 pins set then you would want to set the value you want at once rather than using them as individual pins.

This is still not quite the most convenient for that use-case as it passes around `bool`s instead of e.g. bytes, but it's faster if you want to modify some set of the pins in one go.

I went with `modify()` because so it looks a bit like the one you use for modifying registers. I'm not sure if this would be the best way of exposing this but I think it makes some sense.

Ideally I think there would also be a way to do something like `set()` as well in case you want to reset everything instead of modifying a few of the fields, but I guess that depends on how this change goes.